### PR TITLE
chore(ci): 禁用Garth遥测并移除logfire卸载步骤

### DIFF
--- a/.github/workflows/run_data_sync.yml
+++ b/.github/workflows/run_data_sync.yml
@@ -71,10 +71,6 @@ jobs:
         run: |
           pip install -r requirements.txt
 
-      - name: Uninstall logfire
-        run: |
-          pip uninstall -y logfire
-
       - name: Cache Data Files
         if: env.SAVE_DATA_IN_GITHUB_CACHE == 'true'
         uses: actions/cache@v4

--- a/run_page/garmin_sync.py
+++ b/run_page/garmin_sync.py
@@ -8,6 +8,7 @@ import asyncio
 import datetime as dt
 import logging
 import os
+os.environ["GARTH_TELEMETRY_ENABLED"] = "false"
 import sys
 import time
 import traceback


### PR DESCRIPTION
- 在garmin_sync模块中设置环境变量关闭Garth遥测
- 删除GitHub Actions工作流中卸载logfire的步骤
- 优化CI流程，减少不必要的卸载操作
- 保持数据文件缓存步骤不变